### PR TITLE
CDQ and AFMotion have motion-cocoapods as a dependency

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rake"
+gem "motion-cocoapods"
 gem "redpotion"
 gem "cdq" # Core Data
 gem "afmotion" # Networking


### PR DESCRIPTION
Removing both these gmes causes `rake pod:install` to fail becuase `motion-cocoapods` isn't in the gemfile anymore.