### PR TITLE
Call `application_setup` in the AppDelegate class

### DIFF
--- a/files/app/app_delegate.rb
+++ b/files/app/app_delegate.rb
@@ -3,6 +3,10 @@ class AppDelegate < PM::Delegate
 
   status_bar true, animation: :fade
 
+  # Without this, settings in StandardAppearance will not be correctly applied
+  # Remove this if you aren't using StandardAppearance
+  ApplicationStylesheet.new(nil).application_setup
+
   def on_load(app, options)
     cdq.setup # Remove this if you aren't using CDQ
     open HomeScreen.new(nav_bar: true)


### PR DESCRIPTION
This ensures any settings in StandardAppearance are correctly applied to the app