### PR TITLE
Update motion-cocoapods to latest pre-release

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rake"
-gem "motion-cocoapods"
+gem "motion-cocoapods", "1.8.0.beta.4" # latest version fixes issues with Ruby 2.3
 gem "redpotion"
 gem "cdq" # Core Data
 gem "motion-yaml", "1.4" # Version 1.5 breaks CDQ


### PR DESCRIPTION
The latest version of `motion-cocoapods` resolves a common issue when using Ruby 2.3, which looks something like this:

```
Analyzing dependencies
rake aborted!
NoMethodError: undefined method `to_ary' for #<Pod::Specification name="AFNetworking">
Did you mean?  to_query

Tasks: TOP => pod:install
```

You see this error when generating a new app when Ruby 2.3 is your default version, so it's really hard for newcomers trying to figure out why this is happening.